### PR TITLE
feat: fix misleading uuid decode error on strings with non-matching uuid size

### DIFF
--- a/core/shared/src/main/scala/zio/schema/codec/circe/internal/Codecs.scala
+++ b/core/shared/src/main/scala/zio/schema/codec/circe/internal/Codecs.scala
@@ -61,10 +61,16 @@ private[circe] trait Codecs {
     }
   }
 
+  def decodeUUID: Decoder[java.util.UUID] = Decoder.decodeString.emap { str =>
+    try Right(java.util.UUID.fromString(str))
+    catch {
+      case _: IllegalArgumentException => Left(s"$str is not a valid UUID")
+    }
+  }
+
   def decodeCurrency: Decoder[java.util.Currency] = Decoder.decodeString.emap { str =>
-    try {
-      Right(java.util.Currency.getInstance(str))
-    } catch {
+    try Right(java.util.Currency.getInstance(str))
+    catch {
       case iae: IllegalArgumentException => Left(s"$str is not a valid currency: ${iae.getMessage}")
     }
   }
@@ -120,7 +126,7 @@ private[circe] trait Codecs {
     case StandardType.CharType           => Decoder.decodeChar
     case StandardType.BigIntegerType     => Decoder.decodeBigInt.map(_.underlying)
     case StandardType.BigDecimalType     => Decoder.decodeBigDecimal.map(_.underlying)
-    case StandardType.UUIDType           => Decoder.decodeUUID
+    case StandardType.UUIDType           => decodeUUID
     case StandardType.DayOfWeekType      => Decoder.decodeString.emap(parseJavaTime(java.time.DayOfWeek.valueOf, _))
     case StandardType.DurationType       => Decoder.decodeDuration
     case StandardType.InstantType        => Decoder.decodeInstant

--- a/zio-schema-circe-jsoniter/shared/src/main/scala/zio/schema/codec/circe/jsoniter/internal/Codecs.scala
+++ b/zio-schema-circe-jsoniter/shared/src/main/scala/zio/schema/codec/circe/jsoniter/internal/Codecs.scala
@@ -54,7 +54,7 @@ private[jsoniter] object Codecs extends zio.schema.codec.circe.internal.Codecs {
     case StandardType.CharType           => Decoder.decodeChar
     case StandardType.BigIntegerType     => CirceCodecs.bigIntC3C.map(_.underlying)
     case StandardType.BigDecimalType     => CirceCodecs.bigDecimalC3C.map(_.underlying)
-    case StandardType.UUIDType           => Decoder.decodeUUID
+    case StandardType.UUIDType           => decodeUUID
     case StandardType.DayOfWeekType      => Decoder.decodeString.emap(parseJavaTime(java.time.DayOfWeek.valueOf, _))
     case StandardType.DurationType       => CirceCodecs.durationC3C
     case StandardType.InstantType        => CirceCodecs.instantC3C


### PR DESCRIPTION
original circe's `Decoder[UUID]` pattern matches on
```scala
case Json.JString(string) if string.length == 36 => ...
case json => Left(DecodingFailure(WrongTypeExpectation("string", json), c.history))
```
which can lead to misleading wrong type expectation error where expected type matches provided type